### PR TITLE
Add support for STATICFILES_STORAGE

### DIFF
--- a/pagedown/utils.py
+++ b/pagedown/utils.py
@@ -8,6 +8,12 @@ def compatible_staticpath(path):
     way to do this let me know!
     '''
     try:
+        # staticfiles app
+        from django.contrib.staticfiles.templatetags.staticfiles import static
+        return static(path)
+    except ImportError:
+        pass
+    try:
         # >= 1.4
         from django.templatetags.static import static
         return static(path)


### PR DESCRIPTION
`django.templatetags.static.static` does not take `STATICFILES_STORAGE` into account. This pull request attempts to use `django.contrib.staticfiles.templatetags.staticfiles.static`, which respects the setting, first, before falling back.
